### PR TITLE
TSP-375: Display rating as integer values instead of decimal

### DIFF
--- a/src/main/java/com/github/sportbot/service/LeaderboardService.java
+++ b/src/main/java/com/github/sportbot/service/LeaderboardService.java
@@ -227,11 +227,11 @@ public class LeaderboardService {
      * @return A formatted string displaying the top 5 leaderboard. If the target user is in the top 5,
      *         they are marked with ⬅️. Example output:
      *         🏆Top 5:
-     *         🥇 1. Иван - 110.00
-     *         🥈 2. Андрей - 98.00
-     *         🥉 3. Сергей - 86.00 ⬅️
-     *         ⭐ 4. Анна - 75.38
-     *         ⭐ 5. Николай - 73.83
+     *         🥇 1. Иван - 110
+     *         🥈 2. Андрей - 98
+     *         🥉 3. Сергей - 86 ⬅️
+     *         ⭐ 4. Анна - 75
+     *         ⭐ 5. Николай - 74
      */
     private String messageBuildRating(List<UserScore> scoreList, int userPosition, Locale locale) {
         StringBuilder message = new StringBuilder(
@@ -244,11 +244,11 @@ public class LeaderboardService {
             String medal = (count <= 3) ? medals[count - 1] : "⭐";
 
             if (userPosition >= 0 && count == (userPosition + 1)) {
-                message.append(String.format("%n%s %d. %s - %.2f ⬅️",
-                        medal, count, us.user().getFullName(), us.totalScore()));
+                message.append(String.format("%n%s %d. %s - %d ⬅️",
+                        medal, count, us.user().getFullName(), Math.round(us.totalScore())));
             } else {
-                message.append(String.format("%n%s %d. %s - %.2f",
-                        medal, count, us.user().getFullName(), us.totalScore()));
+                message.append(String.format("%n%s %d. %s - %d",
+                        medal, count, us.user().getFullName(), Math.round(us.totalScore())));
             }
 
             count++;
@@ -269,9 +269,9 @@ public class LeaderboardService {
      * - Пользователь в топ-5: возвращает пустую строку (позиция уже показана в топе)
      * - Пользователь вне топ-5:
      *   ...
-     *   ⭐ 7. Анна - 75.38
-     *   ⭐ 8. Николай - 73.83 ⬅️
-     *   ⭐ 9. Петр - 70.15
+     *   ⭐ 7. Анна - 75
+     *   ⭐ 8. Николай - 74 ⬅️
+     *   ⭐ 9. Петр - 70
      *   ...
      * - Пользователь не найден (userPosition == -1): возвращает пустую строку
      */
@@ -294,15 +294,15 @@ public class LeaderboardService {
         message.append("\n...");
         for (int i = start; i <= end; i++) {
             if (i == userPosition) {
-                message.append(String.format("%n⭐ %d. %s - %.2f ⬅️",
+                message.append(String.format("%n⭐ %d. %s - %d ⬅️",
                         i + 1,
                         scoreList.get(i).user().getFullName(),
-                        scoreList.get(i).totalScore()));
+                        Math.round(scoreList.get(i).totalScore())));
             } else {
-                message.append(String.format("%n⭐ %d. %s - %.2f",
+                message.append(String.format("%n⭐ %d. %s - %d",
                         i + 1,
                         scoreList.get(i).user().getFullName(),
-                        scoreList.get(i).totalScore()));
+                        Math.round(scoreList.get(i).totalScore())));
             }
         }
         message.append("\n...");


### PR DESCRIPTION
Changed leaderboard rating display format from decimal (110.00, 75.38) to integer (110, 75) by using Math.round() with %d format specifier.

Changes:
- LeaderboardService.messageBuildRating(): Use Math.round() for score display
- LeaderboardService.messageBuildUserRating(): Use Math.round() for score display
- Updated JavaDoc examples to reflect integer format

All tests pass (134 tests, 0 failures).